### PR TITLE
Added offsets for Social Club & Epic Games version

### DIFF
--- a/boost.c
+++ b/boost.c
@@ -95,12 +95,21 @@ char __fastcall netcat_insert_dedupe_hooked(uint64_t catalog, uint64_t* key, uin
 void initialize()
 {
   // set up function hooks
-  // addresses hardcoded for Steam version 2215/1.53
   uint64_t base_addr = (uint64_t)GetModuleHandleA(NULL);
-  netcat_insert_dedupe_addr = base_addr + 0x10AA918;
-  strlen_addr = base_addr + 0x17C01A0;
+  
+  if (GetModuleHandleA("steam_api64.dll") == NULL) {
+    // addresses hardcoded for Social Club version 2215/1.53
+    netcat_insert_dedupe_addr = base_addr + 0x10A9664;
+    strlen_addr = base_addr + 0x17BD600;
 
-  netcat_insert_direct = (netcat_insert_direct_t)(base_addr + 0x5BB07C);
+    netcat_insert_direct = (netcat_insert_direct_t)(base_addr + 0x24EA8C);
+  } else {
+    // addresses hardcoded for Steam version 2215/1.53
+    netcat_insert_dedupe_addr = base_addr + 0x10AA918;
+    strlen_addr = base_addr + 0x17C01A0;
+
+    netcat_insert_direct = (netcat_insert_direct_t)(base_addr + 0x5BB07C);
+  }
   
   MH_Initialize();
 


### PR DESCRIPTION
Added a check if game is steam version or not (GetModuleHandleA("steam_api64.dll")), if it's not it uses the offsets for the Social Club version (which are the same offsets as the Epic Games version).

![gta_loading](https://user-images.githubusercontent.com/22227370/109740302-e9e39000-7b7f-11eb-8315-25e0e6def763.png)

**Sigs:**
Call of netcat_insert_dedupe_addr
`E8 ? ? ? ? 84 C0 74 39 8B 47 08`

strlen_addr
`48 8B C1 48 F7 D9`

Call of netcat_insert_direct
`E8 ? ? ? ? 8B 15 ? ? ? ? 0F B7 0D ? ? ? ?`